### PR TITLE
Corrected remote target db to be moodle, not moodle_26

### DIFF
--- a/config/database.php
+++ b/config/database.php
@@ -58,7 +58,7 @@ return [
             'driver' => 'mysql',
             'host' => env('MDL_DB_HOST', '127.0.0.1'),
             'port' => env('MDL_DB_PORT', '1234'),
-            'database' => env('MDL_DB_DATABASE', 'moodle_26'),
+            'database' => env('MDL_DB_DATABASE', 'moodle'),
             'username' => env('MDL_DB_USERNAME', 'root'),
             'password' => env('MDL_DB_PASSWORD', 'root'),
             'unix_socket' => env('MDL_DB_SOCKET', ''),


### PR DESCRIPTION
The symptom for this problem showed as a "Whoops, there was problem..." error message after submitting the date range requested for the report. In determining the root cause, I discovered that an instance of the database 'moodle_26' did not exist on the production WBLMS server but that was the target database specified in /home/forge/default/config/database.php (access to the remote provided by a standing ssh tunnel). I cannot explain why the moodle_26 db is now missing, nor how the reports produced listed any certificate completions occurring after 5/21/2017 (when the db was created as a snapshot of the production db).

Fixed by restoring the ssh tunnel, and reconfiguring the db params to point to the db instance "moodle" on the production server, not "moodle_26".